### PR TITLE
legal: add proprietary LICENSE - All Rights Reserved

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,11 @@
+Copyright (c) 2024-2026 ACHIEVEMOR. All Rights Reserved.
+
+All Rights Reserved. Unauthorized reproduction, fork, or use prohibited.
+
+This repository and all code, documentation, designs, data, and assets
+contained within are the proprietary property of ACHIEVEMOR. No license
+is granted — express or implied — to reproduce, fork, clone, modify,
+distribute, publish, sublicense, or use this work in any form.
+
+Unauthorized access, reproduction, fork, or use constitutes copyright
+infringement and will be pursued to the full extent of the law.


### PR DESCRIPTION
Adds explicit proprietary LICENSE. Part of the batch rollout across core FOAI-AIMS project repos; see BoomerAng9/foai#239 for the full rationale.

Fork button cannot be disabled on user-owned public repos (GitHub platform limit). Separate org migration will land the technical fork-disable alongside this legal signal.

No existing LICENSE in this repo prior to this PR.

Generated with Claude Code.